### PR TITLE
fix(installer): Adiciona a flag --profile app ao comando docker compose

### DIFF
--- a/installer/app.py
+++ b/installer/app.py
@@ -204,7 +204,7 @@ M365_TENANT_ID={form_data.get('M365_TENANT_ID', '')}
 
         # Iniciar serviços em segundo plano
         app.logger.info("Iniciando a instalação dos serviços em segundo plano...")
-        run_docker_command(["docker", "compose", "up", "-d", "--build"], wait=False)
+        run_docker_command(["docker", "compose", "--profile", "app", "up", "-d", "--build"], wait=False)
 
         # Redirecionar para a página de status para acompanhar o progresso
         return redirect(url_for('status'))


### PR DESCRIPTION
O instalador web não estava iniciando os serviços da aplicação porque a chamada ao `docker compose up` não incluía a flag `--profile app`, necessária para ativar os serviços definidos com esse perfil no arquivo docker-compose.yml.

Esta correção adiciona a flag necessária à chamada do comando, garantindo que os serviços da aplicação sejam iniciados corretamente após a conclusão do assistente de instalação.