### PR TITLE
fix(installer): Corrige o caminho de criação do arquivo .env

### DIFF
--- a/installer/app.py
+++ b/installer/app.py
@@ -19,8 +19,8 @@ app.logger.addHandler(handler)
 app.logger.setLevel(logging.INFO)
 
 # Caminhos
-ENV_FILE_PATH = os.path.join('/app', '.env')
-DOCKER_COMPOSE_YML_PATH = '/app'
+ENV_FILE_PATH = os.path.join('/app/config', '.env')
+DOCKER_COMPOSE_YML_PATH = '/app/config'
 
 def check_prerequisites():
     """Verifica se todos os pré-requisitos para a instalação estão atendidos."""


### PR DESCRIPTION
O instalador estava criando o arquivo .env em um local incorreto (`/app/.env`) dentro de seu próprio contêiner, em vez de no volume compartilhado (`/app/config/.env`). Isso fazia com que o arquivo .env não fosse persistido no host, e o comando `docker compose up` falhava por não encontrar as variáveis de ambiente necessárias (como a `JWT_SECRET_KEY`).

Esta alteração corrige o `ENV_FILE_PATH` e o `DOCKER_COMPOSE_YML_PATH` no script `installer/app.py` para garantir que o arquivo de configuração seja criado na raiz do projeto no host, permitindo que o Docker Compose inicie os serviços corretamente.