### PR TITLE
fix(deploy): Corrige erros de inicialização dos serviços do Vault

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,8 +99,7 @@ services:
     container_name: cspmexa-vault-agent-collector
     volumes:
       - vault_secrets_collector:/vault/secrets
-    entrypoint: >
-      vault agent -config=- <<EOF
+    entrypoint: sh -c 'vault agent -config=- <<EOF
       pid_file = "/tmp/pidfile"
       auto_auth {
         method "approle" {
@@ -121,7 +120,7 @@ services:
       vault {
         address = "http://vault:8200"
       }
-      EOF
+      EOF'
     depends_on:
       - vault-setup
 
@@ -186,8 +185,7 @@ services:
     container_name: cspmexa-vault-agent-notification
     volumes:
       - vault_secrets_notification:/vault/secrets
-    entrypoint: >
-      vault agent -config=- <<EOF
+    entrypoint: sh -c 'vault agent -config=- <<EOF
       pid_file = "/tmp/pidfile"
       auto_auth {
         method "approle" {
@@ -208,7 +206,7 @@ services:
       vault {
         address = "http://vault:8200"
       }
-      EOF
+      EOF'
     depends_on:
       - vault-setup
 
@@ -262,8 +260,7 @@ services:
     container_name: cspmexa-vault-agent-api-gateway
     volumes:
       - vault_secrets_api_gateway:/vault/secrets
-    entrypoint: >
-      vault agent -config=- <<EOF
+    entrypoint: sh -c 'vault agent -config=- <<EOF
       pid_file = "/tmp/pidfile"
       auto_auth {
         method "approle" {
@@ -285,7 +282,7 @@ services:
       vault {
         address = "http://vault:8200"
       }
-      EOF
+      EOF'
     depends_on:
       - vault-setup
 

--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
-# Instalar curl e jq
-RUN apk --no-cache add curl jq
+# Instalar curl, jq e bash
+RUN apk --no-cache add curl jq bash
 
 # Copiar o script de setup
 COPY setup-vault.sh /usr/local/bin/setup-vault.sh


### PR DESCRIPTION
Esta alteração aborda dois problemas que impediam a inicialização correta dos serviços do Vault:

1.  O contêiner `vault-setup` falhava com o erro `exec ... no such file or directory` porque o script `setup-vault.sh` requer `bash`, mas o interpretador não estava instalado na imagem base `alpine`. A correção adiciona `bash` ao `Dockerfile` do `vault`.

2.  Os contêineres `vault-agent` falhavam ao carregar suas configurações (`error loading configuration from -`) porque o `entrypoint` no `docker-compose.yml` usava uma sintaxe de `here-document` (<<EOF) que não era interpretada sem um shell. A correção envolve os comandos do `entrypoint` em `sh -c '...'` para garantir a interpretação correta.