### PR TITLE
fix(deploy): Corrige erro de sintaxe YAML no docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,9 @@ services:
     container_name: cspmexa-vault-agent-collector
     volumes:
       - vault_secrets_collector:/vault/secrets
-    entrypoint: sh -c 'vault agent -config=- <<EOF
+    entrypoint: |
+      sh -c '
+      vault agent -config=- <<EOF
       pid_file = "/tmp/pidfile"
       auto_auth {
         method "approle" {
@@ -120,7 +122,8 @@ services:
       vault {
         address = "http://vault:8200"
       }
-      EOF'
+      EOF
+      '
     depends_on:
       - vault-setup
 
@@ -185,7 +188,9 @@ services:
     container_name: cspmexa-vault-agent-notification
     volumes:
       - vault_secrets_notification:/vault/secrets
-    entrypoint: sh -c 'vault agent -config=- <<EOF
+    entrypoint: |
+      sh -c '
+      vault agent -config=- <<EOF
       pid_file = "/tmp/pidfile"
       auto_auth {
         method "approle" {
@@ -206,7 +211,8 @@ services:
       vault {
         address = "http://vault:8200"
       }
-      EOF'
+      EOF
+      '
     depends_on:
       - vault-setup
 
@@ -260,7 +266,9 @@ services:
     container_name: cspmexa-vault-agent-api-gateway
     volumes:
       - vault_secrets_api_gateway:/vault/secrets
-    entrypoint: sh -c 'vault agent -config=- <<EOF
+    entrypoint: |
+      sh -c '
+      vault agent -config=- <<EOF
       pid_file = "/tmp/pidfile"
       auto_auth {
         method "approle" {
@@ -282,7 +290,8 @@ services:
       vault {
         address = "http://vault:8200"
       }
-      EOF'
+      EOF
+      '
     depends_on:
       - vault-setup
 


### PR DESCRIPTION
A alteração anterior para corrigir os `entrypoints` dos `vault-agent` introduziu um erro de sintaxe YAML, fazendo com que o `docker-compose` falhasse com um `yaml.parser.ParserError`.

Esta correção reformata os `entrypoints` dos serviços `vault-agent` usando o indicador de bloco literal (`|`) do YAML. Isso garante que o comando de múltiplas linhas seja tratado como uma única string, preservando a funcionalidade pretendida e resultando em um arquivo `docker-compose.yml` sintaticamente válido.