### PR TITLE
fix(deploy): Remove o uso de perfis do Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ volumes:
 services:
   # --- Banco de Dados ---
   postgres_auth_db:
-    profiles: ["app"]
     image: postgres:13-alpine
     container_name: cspmexa-postgres
     restart: unless-stopped
@@ -35,7 +34,6 @@ services:
 
   # --- Serviços de Backend ---
   auth_service:
-    profiles: ["app"]
     build:
       context: ./backend/auth_service
       dockerfile: Dockerfile
@@ -62,7 +60,6 @@ services:
         condition: service_healthy
 
   collector_service:
-    profiles: ["app"]
     build:
       context: ./backend/collector_service
       dockerfile: Dockerfile
@@ -128,7 +125,6 @@ services:
       - vault-setup
 
   policy_engine_service:
-    profiles: ["app"]
     build:
       context: ./backend/policy_engine_service
       dockerfile: Dockerfile
@@ -153,7 +149,6 @@ services:
         condition: service_completed_successfully
 
   notification_service:
-    profiles: ["app"]
     build:
       context: ./backend/notification_service
       dockerfile: Dockerfile
@@ -217,7 +212,6 @@ services:
       - vault-setup
 
   audit_service:
-    profiles: ["app"]
     build:
       context: ./backend/audit_service
       dockerfile: Dockerfile
@@ -230,7 +224,6 @@ services:
       - cspmexa_net
 
   api_gateway_service:
-    profiles: ["app"]
     build:
       context: ./backend/api_gateway_service
       dockerfile: Dockerfile
@@ -297,7 +290,6 @@ services:
 
   # --- Frontend Build ---
   frontend_build:
-    profiles: ["app"]
     build:
       context: ./frontend/webapp
       dockerfile: Dockerfile
@@ -308,7 +300,6 @@ services:
 
   # --- Nginx Reverse Proxy ---
   nginx:
-    profiles: ["app"]
     image: nginx:latest
     container_name: cspmexa-nginx
     restart: unless-stopped

--- a/installer/app.py
+++ b/installer/app.py
@@ -217,7 +217,7 @@ M365_TENANT_ID={form_data.get('M365_TENANT_ID', '')}
             os.remove(log_file_path)
 
         run_docker_command(
-            ["docker", "compose", "--profile", "app", "up", "-d", "--build"],
+            ["docker", "compose", "up", "-d", "--build"],
             wait=False,
             log_file_path=log_file_path
         )


### PR DESCRIPTION
Para garantir a compatibilidade com versões mais antigas do `docker-compose` que não suportam a flag `--profile`, esta alteração remove o uso de perfis.

- Todas as entradas `profiles: ["app"]` foram removidas do arquivo `docker-compose.yml`. Isso faz com que todos os serviços da aplicação sejam tratados como padrão e iniciados com um simples `docker compose up`.
- A flag `--profile app` foi removida da chamada de comando no script `installer/app.py` para se alinhar com a mudança, evitando erros de 'unknown flag'.

Isso deve resolver as falhas de instalação em ambientes com versões mais antigas do Docker Compose.