### PR TITLE
fix(frontend): Popula o arquivo tsconfig.json vazio

### DIFF
--- a/frontend/webapp/tsconfig.json
+++ b/frontend/webapp/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}


### PR DESCRIPTION
O build do frontend estava falhando com uma avalanche de erros de compilação do TypeScript. A causa raiz era um arquivo `tsconfig.json` completamente vazio.

Esta correção preenche o `tsconfig.json` com uma configuração padrão e funcional para um projeto React + Vite. Isso inclui as flags `"jsx": "react-jsx"` e `"esModuleInterop": true`, que são cruciais para compilar código JSX e lidar com as importações de módulos corretamente.

Esta alteração deve resolver todos os erros de compilação do frontend e permitir que a instalação seja concluída.