### PR TITLE
fix(frontend): Popula o arquivo tsconfig.node.json vazio

### DIFF
--- a/frontend/webapp/tsconfig.node.json
+++ b/frontend/webapp/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}


### PR DESCRIPTION
Após corrigir o `tsconfig.json` principal, o build do frontend ainda falhava com um erro `TS6306`, indicando que o arquivo referenciado `tsconfig.node.json` precisava da opção `"composite": true`.

A investigação revelou que, assim como o arquivo principal, o `tsconfig.node.json` também estava completamente vazio. Esta correção preenche o `tsconfig.node.json` com a configuração apropriada para o ambiente Node.js do Vite, incluindo a flag `"composite": true`.

Com ambos os arquivos de configuração do TypeScript devidamente preenchidos, o processo de compilação deve ser concluído com sucesso.